### PR TITLE
Complete the Add property command

### DIFF
--- a/src/propmgr.Core.xUnit.Tests/Mocks/InMemoryPropertiesFile.cs
+++ b/src/propmgr.Core.xUnit.Tests/Mocks/InMemoryPropertiesFile.cs
@@ -1,0 +1,19 @@
+﻿using System.Collections.Generic;
+using propmgr.Core.Entities;
+
+namespace propmgr.Core.xUnit.Tests.Mocks
+{
+    class InMemoryPropertiesFile : IPropertiesFile
+    {
+        private IEnumerable<PropertyPair> _properties;
+
+        public InMemoryPropertiesFile(IEnumerable<PropertyPair> properties)
+            => _properties = properties;
+
+        public IEnumerable<PropertyPair> GetProperties()
+            => _properties;
+
+        public void SetCollection(IEnumerable<PropertyPair> properties)
+            => _properties = properties;
+    }
+}

--- a/src/propmgr.Core.xUnit.Tests/Mocks/UserConfirmation/AlwaysAcceptingUserConfirmation.cs
+++ b/src/propmgr.Core.xUnit.Tests/Mocks/UserConfirmation/AlwaysAcceptingUserConfirmation.cs
@@ -1,0 +1,10 @@
+﻿using System.Threading.Tasks;
+using propmgr.Core.UserInteraction;
+
+namespace propmgr.Core.xUnit.Tests.Mocks.UserConfirmation
+{
+    class AlwaysAcceptingUserConfirmation : IUserConfirmation
+    {
+        public Task<bool> Confirm(string message) => Task.FromResult(true);
+    }
+}

--- a/src/propmgr.Core.xUnit.Tests/Mocks/UserConfirmation/AlwaysDenyingUserConfirmation.cs
+++ b/src/propmgr.Core.xUnit.Tests/Mocks/UserConfirmation/AlwaysDenyingUserConfirmation.cs
@@ -1,0 +1,10 @@
+﻿using System.Threading.Tasks;
+using propmgr.Core.UserInteraction;
+
+namespace propmgr.Core.xUnit.Tests.Mocks.UserConfirmation
+{
+    class AlwaysDenyingUserConfirmation : IUserConfirmation
+    {
+        public Task<bool> Confirm(string message) => Task.FromResult(false);
+    }
+}

--- a/src/propmgr.Core.xUnit.Tests/propmgr.Core.xUnit.Tests.csproj
+++ b/src/propmgr.Core.xUnit.Tests/propmgr.Core.xUnit.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>

--- a/src/propmgr.Core/IPropertiesFile.cs
+++ b/src/propmgr.Core/IPropertiesFile.cs
@@ -1,0 +1,11 @@
+﻿using propmgr.Core.Entities;
+using System.Collections.Generic;
+
+namespace propmgr.Core
+{
+    public interface IPropertiesFile
+    {
+        IEnumerable<PropertyPair> GetProperties();
+        void SetCollection(IEnumerable<PropertyPair> properties);
+    }
+}

--- a/src/propmgr.Core/UserInteraction/IUserConfirmation.cs
+++ b/src/propmgr.Core/UserInteraction/IUserConfirmation.cs
@@ -1,0 +1,9 @@
+﻿using System.Threading.Tasks;
+
+namespace propmgr.Core.UserInteraction
+{
+    public interface IUserConfirmation
+    {
+        Task<bool> Confirm(string message);
+    }
+}


### PR DESCRIPTION
Implements the Add command.

Features:
- Adding a property with an existing key overwrites the property value.
- Adding a duplicate value asks the user for confirmation
- In other cases, just add the new property at the end of the collection

Structure changes:
- Creates the IUserConfirmation interface
- Creates the IPropertiesFile interface
- Creates a few Test Mocks